### PR TITLE
Remove frame count from client audio packet

### DIFF
--- a/packages/server/server.py
+++ b/packages/server/server.py
@@ -36,6 +36,8 @@ def main():
     local_addr = 'hans.local'
     local_port = int(os.environ['SERVER_PORT'])
     stt_model_file = os.environ['STT_MODEL_FILE']
+    cert_file = os.environ.get('CERT_FILE', 'certs/hans.local.pem')
+    key_file = os.environ.get('KEY_FILE', 'certs/hans.local-key.pem')
 
     vad_model = load_silero_vad()
     voice_detector = VoiceDetector(vad_model)
@@ -59,8 +61,8 @@ def main():
         for packet in listen_for_client_audio(
             local_addr,
             local_port,
-            certfile='certs/hans.local.pem',
-            keyfile='certs/hans.local-key.pem',
+            cert_file=cert_file,
+            key_file=key_file,
         ):
             audio_bytes = packet.audio_bytes
             # TODO: Collect frames until we have enough, don't assume a frame is perfect

--- a/packages/transport/transport.py
+++ b/packages/transport/transport.py
@@ -62,21 +62,21 @@ def _stream_client_audio(
 
 
 def listen_for_client_audio(
-    local_addr: str, local_port: int, certfile: str, keyfile: str
+    local_addr: str, local_port: int, cert_file: str, key_file: str
 ) -> Generator[ClientAudioPacket, None, None]:
     return retry_generator_with_backoff(
-        _listen_for_client_audio, local_addr, local_port, certfile, keyfile
+        _listen_for_client_audio, local_addr, local_port, cert_file, key_file
     )
 
 
 def _listen_for_client_audio(
     local_addr: str,
     local_port: int,
-    certfile: str,
-    keyfile: str,
+    cert_file: str,
+    key_file: str,
 ) -> Generator[ClientAudioPacket, None, None]:
     context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-    context.load_cert_chain(certfile, keyfile)
+    context.load_cert_chain(cert_file, key_file)
 
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as unsecured_sock:
         unsecured_sock.bind((local_addr, local_port))

--- a/packages/transport/transport.py
+++ b/packages/transport/transport.py
@@ -36,7 +36,6 @@ def _stream_client_audio(
     context = ssl.create_default_context()
     with socket.create_connection((addr, port), timeout=1.5) as unsecured_sock:
         with context.wrap_socket(unsecured_sock, server_hostname=addr) as sock:
-            frame_num = 0
             audio_data = bytearray()
             fmt = f'{HEADER_FMT}{AUDIO_CHUNK_SIZE}h'
 
@@ -52,11 +51,6 @@ def _stream_client_audio(
                     sock.send(
                         struct.pack(fmt, FRAME_INDICATOR, AUDIO_CHUNK_SIZE, *chunk)
                     )
-
-                    if frame_num >= MAX_COUNTER:
-                        frame_num = 0
-                    else:
-                        frame_num += 1
 
 
 def listen_for_client_audio(


### PR DESCRIPTION
Now that we're using TCP it's unnecessary
