### PR TITLE
Restrict retry counter to prevent errors

### DIFF
--- a/packages/transport/src/retry.py
+++ b/packages/transport/src/retry.py
@@ -33,6 +33,8 @@ def retry_generator_with_backoff(
             yield from func(*args)
         except Exception as e:
             print(e)
-            sleep_secs = min(STARTING_SLEEP_SECS * (2**retries), MAX_SLEEP_SECS)
+            timeout = STARTING_SLEEP_SECS * (2**retries)
+            sleep_secs = min(timeout, MAX_SLEEP_SECS)
             time.sleep(sleep_secs)
-            retries += 1
+            if timeout < MAX_SLEEP_SECS:
+                retries += 1


### PR DESCRIPTION
When the retry counter became too high, an exception would be thrown when python could no longer convert it to a float.